### PR TITLE
Fixed task 'get token for jenkins api' to allow 404 status code in re…

### DIFF
--- a/tasks/configure-jobs.yml
+++ b/tasks/configure-jobs.yml
@@ -18,6 +18,7 @@
   uri:
     url: '{{ jenkins_url }}:{{ jenkins_port }}/crumbIssuer/api/xml?xpath=concat(//crumbRequestField,":",//crumb)'
     return_content: yes
+    status_code: 200,404
   register: jenkins_token
 
 - name: Reload Jenkins if crumb is enabled


### PR DESCRIPTION
Just a minor tweak to make the 'get token for jenkins api' task work correctly, in configure-jos.yml.